### PR TITLE
Allocate sensor ID 0x84 for maximum altitude

### DIFF
--- a/source/source/ibustelemetry.h
+++ b/source/source/ibustelemetry.h
@@ -46,7 +46,7 @@
 #define IBUS_MEAS_TYPE_GPS_LON			0x81 //4bytes signed WGS84 in degrees * 1E7
 #define IBUS_MEAS_TYPE_GPS_ALT			0x82 //4bytes signed!!! GPS alt m*100
 #define IBUS_MEAS_TYPE_ALT				0x83 //4bytes signed!!! Alt m*100
-#define IBUS_MEAS_TYPE_S84				0x84
+#define IBUS_MEAS_TYPE_ALT_MAX				0x84 //4bytes signed MaxAlt m*100
 #define IBUS_MEAS_TYPE_S85				0x85
 #define IBUS_MEAS_TYPE_S86				0x86
 #define IBUS_MEAS_TYPE_S87				0x87

--- a/source/source/mod.h
+++ b/source/source/mod.h
@@ -83,7 +83,7 @@ const uint8_t __attribute__((section (".mod_sensors80"))) SENSORS_80[] = {
 			'L', 'o', 'n', 0x0, 0x0, /*0x81*/
 			'G', 'A', 'l', 't', 0x0, /*0x82*/
 			'A', 'l', 't', 0x0, 0x0, /*0x83*/
-			'S', '8', '4', 0x0, 0x0, /*0x84*/
+			'M', 'x', 'A', 'l', 0x0, /*0x84*/
 			'S', '8', '5', 0x0, 0x0, /*0x85*/
 			'S', '8', '6', 0x0, 0x0, /*0x86*/
 			'S', '8', '7', 0x0, 0x0, /*0x87*/
@@ -234,7 +234,7 @@ const uint8_t __attribute__((section (".mod_sensDesc80"))) sensorDesc80[] = {
 		CUS_SENSOR|SIGNED__|MUL_001|UNIT_NONE,	//Lon.
 		STD_SENSOR|SIGNED__|MUL_100|UNIT_M,		//Alt -> GPS alt
 		STD_SENSOR|SIGNED__|MUL_100|UNIT_M,		//ALT
-		STD_SENSOR|SIGNED__|MUL_100|UNIT_NONE,	//s84
+		STD_SENSOR|SIGNED__|MUL_100|UNIT_M,	//Max Alt
 		STD_SENSOR|SIGNED__|MUL_100|UNIT_NONE,	//s85
 		STD_SENSOR|SIGNED__|MUL_100|UNIT_NONE,	//s86
 		STD_SENSOR|SIGNED__|MUL_100|UNIT_NONE,	//s87


### PR DESCRIPTION
Hello Kuba!

I am sending a proof-of-concept pull request for allocating the 0x84 sensor ID for maximum altitude sensor, as we discussed at rcgroups:

https://www.rcgroups.com/forums/showthread.php?2486545-FlySky-FS-i6-8-channels-firmware-patch%21/page172

Please review the patch and consider merging it. There are two things I am not sure about:

1) should the sensor name be null-terminated? I used "MxAl" for the sensor name, but I see there are five bytes per sensor in the SENSOR_80[] array. Can the fifth byte also be used? I would rather name the sensor "MxAlt" instead of "MxAl" :-)

2) what is the purpose the sensorsScreens[] array? Should the new IBUS_MEAS_TYPE_ALT_MAX constant also be added to this list?

Thanks,

-Yenya