### PR TITLE
Fix alarms for negative 16-bit sensor values

### DIFF
--- a/source/source/alt.c
+++ b/source/source/alt.c
@@ -449,7 +449,7 @@ void BatteryType() {
 		 for(int i = 0; i < 3; i++){
 			sensorID = modConfig.alarm[i].sensorID;
 			if(sensorID == 0xff) continue;
-			int32_t sensorValue = getSensorValue(sensorID, 0, 0);
+			int32_t sensorValue = (int16_t)getSensorValue(sensorID, 0, 0);
 			if(sensorID >= IBUS_MEAS_TYPE_GPS_LAT && sensorID <= IBUS_MEAS_TYPE_S8a && sensorValue < SENSORS_ARRAY_LENGTH){
 				sensorValue = longSensors[sensorValue];
 			}


### PR DESCRIPTION
Some 16-bit sensors (namely climb rate) can return negative values.
The 16-bit sensor values are returned by getSensorValue as uint16_t,
though. This means negative values are mishandled when the return
value of getSensorValue() is assigned to int32_t sensorValue - the
negative value is converted to 32768..65535 positive range, and alarm
for checking whether - for example - the climb rate is smaller than
-1 m/s does not work.

Avoid this by type cast to int16_t.