### PR TITLE
build/.gitignore: ignore products of compilation

### DIFF
--- a/source/build/.gitignore
+++ b/source/build/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.d
+fs-i6-*.bin
+fs-i6-*.elf
+fs-i6-*.map


### PR DESCRIPTION
Make "git status" output meaningful even without "make clean".