### PR TITLE
alt.h: nextSensorID/prevSensorID assigned to their respective sections

### DIFF
--- a/source/source/alt.h
+++ b/source/source/alt.h
@@ -122,6 +122,8 @@ __attribute__((section (".mod_parseAC"))) void acData(uint8_t* rxBuffer);
  __attribute__((section (".mod_alarmConfig"))) void AlarmConfig();
  __attribute__((section (".mod_customAlarmsCheck"))) void CheckCustomAlarms();
  __attribute__((section (".mod_customAlarmsPlay"))) void play(int freq, int duration, int pause);
+ __attribute__((section (".mod_nextSensorID"))) uint8_t nextSensorID(uint8_t sensorID);
+ __attribute__((section (".mod_prevSensorID"))) uint8_t prevSensorID(uint8_t sensorID);
  __attribute__((section (".mod_swEHandling"))) void swEHandling();
  __attribute__((section (".mod_swBHandling"))) void swBasADC();
  __attribute__((section (".mod_modelConfig"))) modelConfStruct* getModelModConfig();


### PR DESCRIPTION
This amends commit bc002034b0210ff655bc784bf9a5cce8fdd1ab91.

Is there any way to avoid this? Maybe undefine the .text and .data section, so that we get error if we forget to assign a function or variable to a particular section? Or assign .text and .data to some preallocated space?

Sorry for this.